### PR TITLE
README.md: `pipx install --preinstall flake8-kotoha flake8`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 pipx
 
 ```sh
-$ pipx install flake8
-$ pipx inject flake8 flake8-kotoha
+$ pipx install --preinstall flake8-kotoha flake8
 $ flake8 -h
 ...
 Installed plugins: flake8-kotoha: 0.1.0, ...


### PR DESCRIPTION
```diff
- $ pipx install flake8
- $ pipx inject flake8 flake8-kotoha
+ $ pipx install --preinstall flake8-kotoha flake8
```
https://pipx.pypa.io/stable/docs/#pipx-install
```
  --preinstall PREINSTALL
                        Optional package to be installed into the Virtual
                        Environment before installing the main package. Use
                        this flag multiple times if you want to preinstall
                        multiple packages.
```